### PR TITLE
Fix annual income extraction

### DIFF
--- a/get_inividual_data.py
+++ b/get_inividual_data.py
@@ -155,13 +155,11 @@ def get_annual_total(text):
     # Find the monthly income
     income_match = re.search(r"£(\d{1,}(?:,\d{3})*(?:\.\d{2})?)", text)
     if income_match:
-        income = float(income_match.group(1).replace(',', '')[1:])
+        income = float(income_match.group(1).replace(',', ''))
         #print(f"income: {income}") # Debugging
     else:
         # handle the case where no match was found
         return ('error with income_match', date_received)
-
-    income = float(income_match.group(1).replace(',', '')[1:])
 
     # Calculate the total income
     quarter_synonyms = ['a quarter', 'quarterly', 'every three months']


### PR DESCRIPTION
## Summary
- correct slicing error when parsing income values in `get_annual_total`

## Testing
- `python3 -m py_compile get_inividual_data.py Plot_MP_Data.py get_html_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480d0996ec8328912ae9373a43cb02